### PR TITLE
fix: Add automated startup scripts with Docker health checks

### DIFF
--- a/README_QUICK_START.md
+++ b/README_QUICK_START.md
@@ -1,0 +1,170 @@
+# CommandCenter Quick Start Guide
+
+## 🚀 One-Command Startup
+
+```bash
+./start.sh
+```
+
+This script will:
+1. ✅ Check if Docker is running (and start it if needed on macOS)
+2. ✅ Verify `.env` configuration exists
+3. ✅ Stop any existing containers
+4. ✅ Start all services (frontend, backend, database, redis)
+5. ✅ Wait for services to be healthy
+6. ✅ Run database migrations
+7. ✅ Show you the URLs to access
+
+## 🛑 Stop CommandCenter
+
+```bash
+./stop.sh
+```
+
+## 📝 First Time Setup
+
+1. **Clone and navigate to the project:**
+   ```bash
+   cd /path/to/CommandCenter
+   ```
+
+2. **Run the startup script:**
+   ```bash
+   ./start.sh
+   ```
+
+3. **On first run**, the script will:
+   - Create `.env` from `.env.template`
+   - Ask you to configure `SECRET_KEY` and `DB_PASSWORD`
+   - Wait for you to press Enter after editing
+
+4. **Edit `.env`** and set at minimum:
+   ```bash
+   SECRET_KEY=your-secret-key-here
+   DB_PASSWORD=your-strong-password
+   ```
+
+5. **Run again:**
+   ```bash
+   ./start.sh
+   ```
+
+## 🌐 Accessing CommandCenter
+
+Once started, access:
+
+- **Frontend UI**: http://localhost:3000
+- **Backend API**: http://localhost:8000
+- **API Documentation**: http://localhost:8000/docs
+
+## 🎯 Using Multi-Project Features
+
+1. **Navigate to Projects page** (sidebar menu)
+2. **Click "New Project"**
+3. **Fill in project details:**
+   - Name: "My AI Research"
+   - Owner: your-username
+   - Description: (optional)
+4. **Click Create**
+5. **Use the project selector dropdown** in the header to switch between projects
+
+## 🔧 Troubleshooting
+
+### Docker not starting automatically?
+
+**macOS:**
+```bash
+open -a Docker
+# Wait for Docker to start, then run ./start.sh again
+```
+
+**Linux:**
+```bash
+sudo systemctl start docker
+```
+
+**Windows:**
+- Open Docker Desktop manually
+
+### Services not responding?
+
+```bash
+# View logs
+docker-compose logs -f
+
+# Restart specific service
+docker-compose restart backend
+docker-compose restart frontend
+```
+
+### Database issues?
+
+```bash
+# Re-run migrations
+docker-compose exec backend alembic upgrade head
+
+# Reset database (WARNING: destroys all data)
+docker-compose down -v
+./start.sh
+```
+
+### Port conflicts?
+
+Check what's using the ports:
+```bash
+# macOS/Linux
+lsof -i :3000  # Frontend
+lsof -i :8000  # Backend
+lsof -i :5432  # PostgreSQL
+lsof -i :6379  # Redis
+```
+
+Change ports in `.env` if needed:
+```bash
+FRONTEND_PORT=3001
+BACKEND_PORT=8001
+POSTGRES_PORT=5433
+REDIS_PORT=6380
+```
+
+## 📚 Additional Documentation
+
+- **Full Setup Guide**: `CLAUDE.md`
+- **Multi-Project Architecture**: `PHASE1B_STATUS_REPORT.md`
+- **API Documentation**: http://localhost:8000/docs (when running)
+
+## 🆘 Need Help?
+
+If you encounter issues:
+
+1. Check the logs: `docker-compose logs -f`
+2. Ensure Docker is running: `docker info`
+3. Verify `.env` is configured: `cat .env`
+4. Try a clean restart: `./stop.sh && ./start.sh`
+
+---
+
+**Quick Commands Reference:**
+
+```bash
+# Start everything
+./start.sh
+
+# Stop everything
+./stop.sh
+
+# View logs
+docker-compose logs -f
+
+# Restart a service
+docker-compose restart backend
+
+# Run migrations
+docker-compose exec backend alembic upgrade head
+
+# Access database shell
+docker-compose exec postgres psql -U commandcenter
+
+# Access backend shell
+docker-compose exec backend bash
+```

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+echo -e "${BLUE}╔════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║     CommandCenter Startup Script          ║${NC}"
+echo -e "${BLUE}╔════════════════════════════════════════════╗${NC}"
+echo ""
+
+# Function to check if Docker is running
+check_docker() {
+    echo -e "${YELLOW}→${NC} Checking if Docker is running..."
+
+    if ! docker info > /dev/null 2>&1; then
+        echo -e "${RED}✗${NC} Docker is not running!"
+        echo ""
+        echo -e "${YELLOW}Please start Docker Desktop:${NC}"
+        echo "  1. Open Docker Desktop application"
+        echo "  2. Wait for Docker to fully start"
+        echo "  3. Run this script again"
+        echo ""
+
+        # Try to open Docker Desktop automatically (macOS)
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            echo -e "${YELLOW}→${NC} Attempting to open Docker Desktop..."
+            open -a Docker
+            echo ""
+            echo -e "${YELLOW}Waiting for Docker to start...${NC}"
+
+            # Wait up to 60 seconds for Docker to start
+            COUNTER=0
+            while ! docker info > /dev/null 2>&1 && [ $COUNTER -lt 60 ]; do
+                sleep 2
+                ((COUNTER+=2))
+                echo -n "."
+            done
+            echo ""
+
+            if docker info > /dev/null 2>&1; then
+                echo -e "${GREEN}✓${NC} Docker is now running!"
+            else
+                echo -e "${RED}✗${NC} Docker failed to start. Please start it manually."
+                exit 1
+            fi
+        else
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}✓${NC} Docker is running"
+    fi
+}
+
+# Function to check if .env exists
+check_env() {
+    echo -e "${YELLOW}→${NC} Checking environment configuration..."
+
+    if [ ! -f .env ]; then
+        echo -e "${YELLOW}!${NC} .env file not found. Creating from template..."
+        if [ -f .env.template ]; then
+            cp .env.template .env
+            echo -e "${GREEN}✓${NC} Created .env from template"
+            echo -e "${YELLOW}!${NC} Please edit .env and add your configuration (especially SECRET_KEY and DB_PASSWORD)"
+            echo ""
+            read -p "Press Enter to continue after updating .env, or Ctrl+C to exit..."
+        else
+            echo -e "${RED}✗${NC} .env.template not found!"
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}✓${NC} .env file exists"
+    fi
+}
+
+# Function to stop any running containers
+stop_existing() {
+    echo -e "${YELLOW}→${NC} Stopping any existing CommandCenter containers..."
+    docker-compose down > /dev/null 2>&1 || true
+    echo -e "${GREEN}✓${NC} Stopped existing containers"
+}
+
+# Function to start services
+start_services() {
+    echo -e "${YELLOW}→${NC} Starting CommandCenter services..."
+    echo ""
+
+    docker-compose up -d
+
+    if [ $? -eq 0 ]; then
+        echo ""
+        echo -e "${GREEN}✓${NC} Services started successfully!"
+    else
+        echo -e "${RED}✗${NC} Failed to start services"
+        exit 1
+    fi
+}
+
+# Function to wait for services to be healthy
+wait_for_services() {
+    echo -e "${YELLOW}→${NC} Waiting for services to be ready..."
+
+    # Wait for backend to be healthy
+    COUNTER=0
+    until curl -s http://localhost:8000/health > /dev/null 2>&1 || [ $COUNTER -eq 30 ]; do
+        sleep 2
+        ((COUNTER+=2))
+        echo -n "."
+    done
+    echo ""
+
+    if curl -s http://localhost:8000/health > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} Backend is ready"
+    else
+        echo -e "${YELLOW}!${NC} Backend may still be starting up"
+    fi
+}
+
+# Function to run database migrations
+run_migrations() {
+    echo -e "${YELLOW}→${NC} Running database migrations..."
+
+    if docker-compose exec -T backend alembic upgrade head > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} Database migrations completed"
+    else
+        echo -e "${YELLOW}!${NC} Migrations may have failed - check logs if needed"
+    fi
+}
+
+# Function to show status
+show_status() {
+    echo ""
+    echo -e "${BLUE}╔════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║         CommandCenter is Ready!            ║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo -e "${GREEN}Services running:${NC}"
+    docker-compose ps
+    echo ""
+    echo -e "${GREEN}Access your CommandCenter:${NC}"
+    echo -e "  Frontend:  ${BLUE}http://localhost:3000${NC}"
+    echo -e "  Backend:   ${BLUE}http://localhost:8000${NC}"
+    echo -e "  API Docs:  ${BLUE}http://localhost:8000/docs${NC}"
+    echo ""
+    echo -e "${GREEN}Useful commands:${NC}"
+    echo -e "  View logs:        ${YELLOW}docker-compose logs -f${NC}"
+    echo -e "  Stop services:    ${YELLOW}docker-compose down${NC}"
+    echo -e "  Restart services: ${YELLOW}docker-compose restart${NC}"
+    echo ""
+}
+
+# Main execution
+main() {
+    check_docker
+    check_env
+    stop_existing
+    start_services
+    wait_for_services
+    run_migrations
+    show_status
+}
+
+# Run main function
+main

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+echo -e "${BLUE}╔════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║     CommandCenter Stop Script              ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════╝${NC}"
+echo ""
+
+echo -e "${YELLOW}→${NC} Stopping CommandCenter services..."
+docker-compose down
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}✓${NC} CommandCenter stopped successfully!"
+else
+    echo -e "${RED}✗${NC} Failed to stop services"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds smart startup scripts that check if Docker is running and automatically handle service startup, migrations, and health checks.

## Problem Solved

User gets "site can't be reached" error when Docker isn't running. This PR adds intelligent startup scripts that:

1. ✅ Check if Docker daemon is running
2. ✅ Auto-start Docker Desktop on macOS if needed
3. ✅ Wait for Docker to be fully ready
4. ✅ Verify environment configuration
5. ✅ Start all services in correct order
6. ✅ Wait for services to be healthy
7. ✅ Run database migrations automatically
8. ✅ Show clear status and URLs

## New Files

- `start.sh` - Main startup script with health checks
- `stop.sh` - Clean shutdown script
- `README_QUICK_START.md` - User-friendly quick start guide

## Usage

```bash
# Start everything (one command!)
./start.sh

# Stop everything
./stop.sh
```

## Features

- **Auto-detect Docker**: Checks `docker info` before proceeding
- **Auto-start Docker**: Opens Docker Desktop on macOS automatically
- **Health checks**: Waits for backend API to respond
- **Auto-migrations**: Runs `alembic upgrade head` 
- **User-friendly**: Color-coded output with clear status messages
- **Error handling**: Graceful failures with helpful messages

## Testing

Tested scenarios:
- ✅ Docker not running → Auto-starts and waits
- ✅ .env missing → Creates from template and prompts user
- ✅ Services already running → Cleanly restarts
- ✅ All services start successfully → Shows URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)