### PR TITLE
fix: Remove duplicate idx_research_tasks_status index in migration

### DIFF
--- a/backend/alembic/versions/012_performance_indexes.py
+++ b/backend/alembic/versions/012_performance_indexes.py
@@ -100,13 +100,8 @@ def upgrade() -> None:
             unique=False
         )
 
-    # Add index for research tasks filtering (only on status, priority column doesn't exist)
-    op.create_index(
-        'idx_research_tasks_status',
-        'research_tasks',
-        ['status'],
-        unique=False
-    )
+    # Note: idx_research_tasks_status already exists from migration a1b2c3d4e5f6
+    # No need to create it again
 
     # Add index for knowledge entries
     if op.get_bind().dialect.has_table(op.get_bind(), 'knowledge_entries'):
@@ -167,7 +162,7 @@ def downgrade() -> None:
 
     # Drop cross-database indexes
     op.drop_index('idx_jobs_project_type_status', table_name='jobs')
-    op.drop_index('idx_research_tasks_status', table_name='research_tasks')
+    # Note: idx_research_tasks_status managed by migration a1b2c3d4e5f6
 
     # Drop knowledge entries index if table exists
     if op.get_bind().dialect.has_table(op.get_bind(), 'knowledge_entries'):


### PR DESCRIPTION
## Summary

Fixes #48 - Removes duplicate database index that was blocking fresh installations and hub project spawning.

## Problem

Migration `012_performance_indexes.py` was creating a duplicate index `idx_research_tasks_status` that already exists from migration `a1b2c3d4e5f6_add_database_indexes.py`.

**Error on fresh databases**:
```
idx_research_tasks_status already exists
```

## Impact Before Fix

- ❌ **Blocked hub project spawning** - New projects couldn't start
- ❌ **Blocked fresh installations** - `alembic upgrade head` failed
- ❌ **Backend exits with code 1** - Prevents all new deployments
- ✅ **Existing databases unaffected** - Already have the index from first migration

## Solution

**Removed duplicate index creation** from `012_performance_indexes.py`:
- ✅ Removed `op.create_index('idx_research_tasks_status', ...)` from `upgrade()`
- ✅ Removed `op.drop_index('idx_research_tasks_status', ...)` from `downgrade()`
- ✅ Added comments explaining index is managed by earlier migration

**Original index preserved** in `a1b2c3d4e5f6_add_database_indexes.py`:
- ✅ Still creates the index (lines 104-109)
- ✅ Still drops the index on downgrade (line 160)
- ✅ Properly manages the index lifecycle

## Changes

**File**: `backend/alembic/versions/012_performance_indexes.py`
- Lines 103-109: Removed duplicate `op.create_index()`
- Line 165: Removed duplicate `op.drop_index()`
- Added explanatory comments

**Verification**:
```bash
grep -n "idx_research_tasks_status" backend/alembic/versions/*.py
```

**Output**:
```
012_performance_indexes.py:103:    # Note: idx_research_tasks_status already exists from migration a1b2c3d4e5f6
012_performance_indexes.py:165:    # Note: idx_research_tasks_status managed by migration a1b2c3d4e5f6
a1b2c3d4e5f6_add_database_indexes.py:105:        'idx_research_tasks_status',  ✅ Original
a1b2c3d4e5f6_add_database_indexes.py:160:    op.drop_index('idx_research_tasks_status', ...)  ✅ Original
```

Only one migration now creates/manages the index ✅

## Testing

- [x] Verified only one migration creates the index
- [x] Verified only one migration drops the index
- [x] Comments document why duplicate was removed
- [x] No changes to original migration maintaining backwards compatibility

## Impact After Fix

- ✅ Fresh installations will succeed
- ✅ Hub project spawning will work
- ✅ Existing databases continue working (no-op, index already exists)
- ✅ Migration history remains valid

## Related

- Fixes #48
- Discovered during testing of PR #47
- Unblocks full end-to-end hub testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>