### PR TITLE
fix: Flake8 cleanup - resolve E226 error (51 → 50 errors)

### DIFF
--- a/backend/app/tasks/job_tasks.py
+++ b/backend/app/tasks/job_tasks.py
@@ -234,7 +234,7 @@ async def execute_batch_analysis_job(
         await service.update_job(
             job_id=job_id,
             progress=progress,
-            current_step=f"Analyzing repository {i+1}/{total}",
+            current_step=f"Analyzing repository {i + 1}/{total}",
         )
 
         # TODO: Implement actual analysis


### PR DESCRIPTION
## Summary

Fixes the last non-E501 Flake8 error on main branch. This PR supersedes closed PR #72 which had extensive merge conflicts.

## Changes Made

**E226 Fixed (1 error):**
- `app/tasks/job_tasks.py:237` - Added whitespace around `+` operator
- Changed `{i+1}` to `{i + 1}` for PEP 8 compliance

## Flake8 Status

**Before:**
```bash
flake8 app/ --max-line-length=100 --exclude=__pycache__,migrations --ignore=E203,W503
# Result: 51 errors (50 E501 + 1 E226)
```

**After:**
```bash
flake8 app/ --max-line-length=100 --exclude=__pycache__,migrations --ignore=E203,W503
# Result: 50 errors (all E501)
```

**All non-E501 errors are now fixed! ✅**

## Remaining E501 Errors (50)

All remaining errors are **E501 (line too long)** in:
- `exporters/html.py` - Long HTML template strings (5 errors)
- `exporters/sarif.py` - Generated SARIF JSON (2 errors)  
- `mcp/providers/commandcenter_prompts.py` - MCP prompt strings (9 errors)
- `models/*.py` - Long field definitions (5 errors)
- `routers/` - Long URLs and strings (4 errors)
- `services/` - Long log messages and queries (10 errors)
- `tasks/` - Long log messages (3 errors)
- Other files - Various long strings (12 errors)

**These are low-priority cosmetic issues** - hard to break without reducing readability.

## Decision Rationale

✅ **Ready to merge** because:
1. All **critical errors** (undefined names, missing imports, syntax) are already fixed
2. Only **cosmetic E501 errors** remain (line length)
3. E501 violations are in generated code, templates, and log strings
4. Breaking these lines often reduces readability
5. Can be addressed incrementally when files are touched for other reasons

## Related

- **Closes:** #72 (superseded - had merge conflicts)
- **Context:** Post-Phase B linting cleanup
- **Next:** E501 errors can be fixed incrementally or ignored with noqa comments

## Testing

```bash
# Run Flake8 check
python3 -m flake8 app/ --max-line-length=100 --exclude=__pycache__,migrations --ignore=E203,W503,E501
# Result: 0 errors ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>