### PR TITLE
feat(monitoring): Deploy AlertManager

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.middleware import LoggingMiddleware, add_security_headers, limiter
 from app.middleware.correlation import CorrelationIDMiddleware
 from app.nats_client import init_nats_client, shutdown_nats_client
 from app.routers import (
+    alerts,
     auth,
     batch,
     dashboard,
@@ -263,6 +264,7 @@ app.include_router(
     intelligence.router, prefix=settings.api_v1_prefix
 )  # Research Hub intelligence integration
 app.include_router(settings_router.router, prefix=settings.api_v1_prefix)  # Settings & API keys
+app.include_router(alerts.router)  # AlertManager webhook integration
 
 
 # Test endpoints for observability (only in dev/test environments)

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -1,0 +1,80 @@
+"""Alert webhook endpoint for AlertManager integration."""
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, BackgroundTasks
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/alerts", tags=["alerts"])
+
+
+class AlertLabel(BaseModel):
+    alertname: str
+    severity: Optional[str] = None
+    service: Optional[str] = None
+    instance: Optional[str] = None
+
+
+class Alert(BaseModel):
+    status: str  # "firing" or "resolved"
+    labels: AlertLabel
+    annotations: dict = {}
+    startsAt: str
+    endsAt: Optional[str] = None
+    generatorURL: Optional[str] = None
+    fingerprint: str
+
+
+class AlertManagerWebhook(BaseModel):
+    receiver: str
+    status: str
+    alerts: List[Alert]
+    groupLabels: dict = {}
+    commonLabels: dict = {}
+    commonAnnotations: dict = {}
+    externalURL: str
+    version: str = "4"
+    groupKey: str
+
+
+@router.post("/webhook")
+async def receive_alert(payload: AlertManagerWebhook, background_tasks: BackgroundTasks):
+    """
+    Receive alerts from AlertManager webhook.
+    
+    This endpoint logs alerts and could be extended to:
+    - Store in database
+    - Send to Slack/Discord
+    - Trigger automated remediation
+    - Update dashboard status
+    """
+    for alert in payload.alerts:
+        if alert.status == "firing":
+            logger.warning(
+                f"🚨 ALERT FIRING: {alert.labels.alertname} "
+                f"(severity: {alert.labels.severity}, service: {alert.labels.service})"
+            )
+        else:
+            logger.info(
+                f"✅ ALERT RESOLVED: {alert.labels.alertname} "
+                f"(service: {alert.labels.service})"
+            )
+    
+    # Could add background task for async processing
+    # background_tasks.add_task(store_alerts, payload)
+    
+    return {"status": "received", "alert_count": len(payload.alerts)}
+
+
+@router.get("/health")
+async def alerts_health():
+    """Health check for alerts subsystem."""
+    return {
+        "status": "healthy",
+        "alertmanager_url": "http://alertmanager:9093",
+        "timestamp": datetime.utcnow().isoformat()
+    }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -241,6 +241,40 @@ services:
         limits:
           memory: 2G
 
+
+  # AlertManager - Alert Management and Routing
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: ${COMPOSE_PROJECT_NAME:-commandcenter}_alertmanager
+    restart: unless-stopped
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--web.external-url=https://alertmanager.${DOMAIN}'
+      - '--cluster.listen-address='
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.alertmanager.rule=Host(`alertmanager.${DOMAIN}`)"
+      - "traefik.http.routers.alertmanager.entrypoints=websecure"
+      - "traefik.http.routers.alertmanager.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.alertmanager.middlewares=alertmanager-auth"
+      - "traefik.http.middlewares.alertmanager-auth.basicauth.users=${ALERTMANAGER_USER}"
+      - "traefik.http.services.alertmanager.loadbalancer.server.port=9093"
+    networks:
+      - monitoring
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
   # Grafana - Metrics Visualization
   grafana:
     image: grafana/grafana:10.2.2
@@ -374,6 +408,8 @@ volumes:
   traefik_logs:
     driver: local
   backend_logs:
+    driver: local
+  alertmanager_data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,20 @@ services:
     networks:
       - commandcenter
 
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: ${COMPOSE_PROJECT_NAME:-commandcenter}_alertmanager
+    restart: unless-stopped
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    networks:
+      - commandcenter
+
 volumes:
   postgres_data:
     driver: local

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,91 @@
+# AlertManager configuration for CommandCenter
+# Docs: https://prometheus.io/docs/alerting/latest/configuration/
+
+global:
+  resolve_timeout: 5m
+  # SMTP settings (uncomment and configure for email alerts)
+  # smtp_smarthost: 'smtp.gmail.com:587'
+  # smtp_from: 'alertmanager@commandcenter.local'
+  # smtp_auth_username: 'your-email@gmail.com'
+  # smtp_auth_password: 'app-password'
+
+# Route tree - how alerts flow through receivers
+route:
+  # Default receiver
+  receiver: 'default-receiver'
+  
+  # Group alerts by these labels
+  group_by: ['alertname', 'severity', 'service']
+  
+  # Wait before sending first notification for a group
+  group_wait: 30s
+  
+  # Wait before sending updated notification for existing group
+  group_interval: 5m
+  
+  # Wait before resending a notification
+  repeat_interval: 4h
+  
+  # Child routes for different severities
+  routes:
+    # Critical alerts - immediate notification
+    - match:
+        severity: critical
+      receiver: 'critical-receiver'
+      group_wait: 10s
+      repeat_interval: 1h
+    
+    # Warning alerts - normal timing
+    - match:
+        severity: warning
+      receiver: 'warning-receiver'
+      repeat_interval: 4h
+    
+    # Page-worthy alerts
+    - match:
+        severity: page
+      receiver: 'pager-receiver'
+      group_wait: 0s
+      repeat_interval: 5m
+
+# Receivers - where alerts go
+receivers:
+  - name: 'default-receiver'
+    # Webhook to CommandCenter backend (optional - implement endpoint if needed)
+    webhook_configs:
+      - url: 'http://backend:8000/api/v1/alerts/webhook'
+        send_resolved: true
+        # Don't fail if endpoint doesn't exist yet
+        http_config:
+          follow_redirects: true
+
+  - name: 'critical-receiver'
+    webhook_configs:
+      - url: 'http://backend:8000/api/v1/alerts/webhook'
+        send_resolved: true
+
+  - name: 'warning-receiver'
+    webhook_configs:
+      - url: 'http://backend:8000/api/v1/alerts/webhook'
+        send_resolved: true
+
+  - name: 'pager-receiver'
+    webhook_configs:
+      - url: 'http://backend:8000/api/v1/alerts/webhook'
+        send_resolved: true
+
+# Inhibition rules - suppress alerts based on other alerts
+inhibit_rules:
+  # If service is down, inhibit high latency alerts for that service
+  - source_match:
+      alertname: 'ServiceDown'
+    target_match:
+      alertname: 'HighRequestLatency'
+    equal: ['service']
+  
+  # If database is down, inhibit connection pool alerts
+  - source_match:
+      alertname: 'PostgresqlDown'
+    target_match:
+      alertname: 'PostgresqlTooManyConnections'
+    equal: ['instance']

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -6,12 +6,15 @@ global:
     cluster: 'commandcenter'
     environment: 'production'
 
-# Alertmanager configuration (optional, can be added later)
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets:
-#             - alertmanager:9093
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+      timeout: 10s
+      api_version: v2
+
 
 # Load rules once and periodically evaluate them
 rule_files:


### PR DESCRIPTION
## Summary
Deploys AlertManager to enable the 23 existing alert rules to actually fire. Previously, alert rules were defined in `monitoring/alerts.yml` but AlertManager was not deployed, so alerts never triggered.

## Changes
- Created `monitoring/alertmanager.yml` configuration with:
  - Severity-based routing (critical, warning, page)
  - Webhook receivers pointing to backend API
  - Inhibition rules to suppress redundant alerts
- Added AlertManager service to `docker-compose.prod.yml` with:
  - Prometheus AlertManager v0.27.0
  - Traefik integration
  - Persistent volume for alert data
  - Health checks
- Added AlertManager service to `docker-compose.yml` for development
- Updated `monitoring/prometheus.yml` to connect to AlertManager
- Created `/api/v1/alerts/webhook` endpoint in backend:
  - Receives AlertManager webhook payloads
  - Logs alerts with severity and service info
  - Health check endpoint at `/api/v1/alerts/health`
- Registered alerts router in `backend/app/main.py`

## Files Changed (6 files, +232/-6)
- `monitoring/alertmanager.yml` (new - 91 lines)
- `backend/app/routers/alerts.py` (new - 80 lines)
- `docker-compose.prod.yml` (+36 lines)
- `docker-compose.yml` (+14 lines)
- `monitoring/prometheus.yml` (updated alerting config)
- `backend/app/main.py` (+2 lines)

## Testing
```bash
# Start services
docker-compose -f docker-compose.prod.yml up -d alertmanager prometheus

# Verify AlertManager is running
curl http://localhost:9093/-/healthy

# Check Prometheus can reach AlertManager
curl http://localhost:9090/api/v1/alertmanagers

# Verify alert rules are loaded
curl http://localhost:9090/api/v1/rules
```

## Impact
Enables monitoring alerts that were previously defined but never fired. The 23 alert rules in `monitoring/alerts.yml` will now trigger notifications.