### PR TITLE
feat(vislzr): add affordance execution via API

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Central export file for all React hooks
+ */
+
+export { useAffordances } from './useAffordances';
+export type { UseAffordancesReturn } from './useAffordances';
+
+export { useDashboard } from './useDashboard';
+export { 
+  useProjectGraph, 
+  useGraphSearch, 
+  useFederationQuery, 
+  useSymbolDependencies 
+} from './useGraph';
+export type {
+  UseProjectGraphResult,
+  UseGraphSearchResult,
+  UseFederationQueryResult,
+  UseSymbolDependenciesResult,
+} from './useGraph';
+export { useKnowledge } from './useKnowledge';
+export { useProjects } from './useProjects';
+export { useQueryState } from './useQueryState';
+export type { UseQueryStateReturn } from './useQueryState';
+export { useRepositories } from './useRepositories';
+export { useResearchSummary } from './useResearchSummary';
+export { useResearchTaskList } from './useResearchTaskList';
+export { useResearchTasks } from './useResearchTasks';
+export { useTechnologies } from './useTechnologies';
+export { useWebSocket } from './useWebSocket';

--- a/frontend/src/hooks/useAffordances.ts
+++ b/frontend/src/hooks/useAffordances.ts
@@ -1,0 +1,96 @@
+/**
+ * useAffordances - React hook for executing affordance actions
+ *
+ * Provides a function to execute affordances with automatic handling of:
+ * - Navigation actions (updates URL search params)
+ * - Created/triggered actions (logs messages)
+ * - Data actions (returns data)
+ * - Error handling
+ */
+
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { Affordance } from '../types/query';
+import { executeAffordance, ExecuteActionResponse } from '../services/actionApi';
+
+export interface UseAffordancesReturn {
+  /** Execute an affordance action */
+  execute: (affordance: Affordance) => Promise<ExecuteActionResponse>;
+  /** Check if an action is currently executing */
+  isExecuting: boolean;
+}
+
+/**
+ * Hook for executing affordance actions
+ *
+ * @returns Object with execute function and loading state
+ */
+export function useAffordances(): UseAffordancesReturn {
+  const [, setSearchParams] = useSearchParams();
+
+  const execute = useCallback(
+    async (affordance: Affordance): Promise<ExecuteActionResponse> => {
+      try {
+        // Execute the affordance via API
+        const result = await executeAffordance(affordance);
+
+        // Handle different result types
+        switch (result.result_type) {
+          case 'navigate': {
+            // Update URL search params with the new query
+            if (result.query) {
+              const newParams = new URLSearchParams();
+              
+              // Merge query parameters into URL
+              Object.entries(result.query).forEach(([key, value]) => {
+                if (value !== null && value !== undefined) {
+                  // Convert arrays and objects to JSON strings
+                  const stringValue = 
+                    typeof value === 'object' 
+                      ? JSON.stringify(value) 
+                      : String(value);
+                  newParams.set(key, stringValue);
+                }
+              });
+              
+              setSearchParams(newParams);
+            }
+            break;
+          }
+
+          case 'created':
+          case 'triggered': {
+            // Log the message (toast can be added later)
+            console.log(`[Affordance] ${result.result_type}: ${result.message}`);
+            break;
+          }
+
+          case 'data': {
+            // Data is returned in the result, caller can use it
+            console.log(`[Affordance] Data result: ${result.message}`);
+            break;
+          }
+
+          default: {
+            console.warn(`[Affordance] Unknown result type: ${result.result_type}`);
+          }
+        }
+
+        return result;
+      } catch (error) {
+        console.error('[Affordance] Execution failed:', error);
+        throw error;
+      }
+    },
+    [setSearchParams]
+  );
+
+  // For now, we don't track execution state
+  // This can be enhanced with useState if needed
+  const isExecuting = false;
+
+  return {
+    execute,
+    isExecuting,
+  };
+}

--- a/frontend/src/services/actionApi.ts
+++ b/frontend/src/services/actionApi.ts
@@ -1,0 +1,43 @@
+/**
+ * Action API Client for VISLZR Affordances
+ *
+ * Handles execution of affordance actions via the backend API.
+ */
+
+import api from './api';
+import type { Affordance } from '../types/query';
+
+/**
+ * Response from executing an affordance action
+ */
+export interface ExecuteActionResponse {
+  /** Type of result */
+  result_type: 'navigate' | 'created' | 'triggered' | 'data';
+  /** Human-readable message about what happened */
+  message: string;
+  /** Navigation query (if result_type is 'navigate') */
+  query?: Record<string, unknown>;
+  /** Created entity data (if result_type is 'created') */
+  data?: unknown;
+}
+
+/**
+ * Execute an affordance action via the backend API
+ *
+ * @param affordance - The affordance to execute
+ * @returns Promise resolving to the action execution result
+ */
+export async function executeAffordance(
+  affordance: Affordance
+): Promise<ExecuteActionResponse> {
+  const response = await api.post<ExecuteActionResponse>(
+    '/api/v1/graph/actions',
+    {
+      action: affordance.action,
+      target: affordance.target,
+      parameters: affordance.parameters || {},
+    }
+  );
+
+  return response.data;
+}


### PR DESCRIPTION
## Summary
Implements Task 5 of Sprint 3: Wire affordance execution to the backend API.

### Changes
- **Created `frontend/src/services/actionApi.ts`**: API client for executing affordance actions via POST /api/v1/graph/actions
- **Created `frontend/src/hooks/useAffordances.ts`**: React hook that:
  - Executes affordances via the API
  - Handles navigation result type by updating URL search params
  - Handles created/triggered result types with console logging (toast integration can be added later)
  - Handles data result type for custom data responses
- **Created `frontend/src/hooks/index.ts`**: Central export file for all hooks

### Result Types Handled
- `navigate`: Updates URL search params with new query
- `created`: Logs creation message
- `triggered`: Logs trigger message
- `data`: Returns data to caller

### Verification
- ✅ TypeScript compilation passes with no errors
- ✅ AffordanceAction type exists in frontend/src/types/query.ts
- ✅ Uses react-router-dom's useSearchParams for navigation
- ✅ All files follow existing code patterns

### Test Plan
- [ ] Import and use `useAffordances` hook in a component
- [ ] Test navigation result type updates URL correctly
- [ ] Test created/triggered result types log messages
- [ ] Verify API request format matches backend expectations
- [ ] Integration test with actual backend endpoint

Related to Sprint 3 implementation plan.